### PR TITLE
Use best resolution for device and resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,10 @@ let app = new PIXI.Application({
   width: window.innerWidth,
   height: window.innerHeight,
   antialias: true,
-  resolution: 1
+  resolution: window.devicePixelRatio || 1,
+  autoResize: true
 });
+
 app.renderer.backgroundColor = 0x444444;
 app.renderer.view.style.position = "absolute";
 app.renderer.view.style.display = "block";


### PR DESCRIPTION
Font is a little blurry on a HiDPI screen. This PR detects the device resolution and use that if valid, with a fallback to the original `1`. The resolution is then auto resized.

Before
<img width="1590" alt="Screenshot 2020-07-12 at 18 26 11" src="https://user-images.githubusercontent.com/294376/87252715-32bdcb80-c46d-11ea-8ce9-ac6b57e759c4.png">

After
<img width="1592" alt="Screenshot 2020-07-12 at 18 22 38" src="https://user-images.githubusercontent.com/294376/87252726-42d5ab00-c46d-11ea-912b-440f0a351dd2.png">
